### PR TITLE
Add Flask asset manager example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+instance/
+*.db
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# test
+# Flask Asset Manager
+
+This project demonstrates a small web application built with **Flask** and
+**SQLite** for managing IT assets. It showcases common programming concepts such
+as routing, templating, database interaction using ORM, authentication, and role
+based access control. The app follows a modular design with reusable
+components and includes automated tests with `pytest`.
+
+## Agile Approach
+
+Development was planned in small increments. Features were prioritised and
+implemented iteratively:
+
+1. Set up project structure and database models.
+2. Implemented user registration and authentication.
+3. Added CRUD operations for assets with role checks.
+4. Created simple templates for usability.
+5. Wrote automated tests to cover main functionality.
+6. Updated documentation and sample data.
+
+Each step could represent an iteration in an Agile process, allowing feedback to
+shape the next phase.
+
+## Running the application
+
+Install the dependencies and start the development server:
+
+```bash
+pip install -r requirements.txt
+python run.py
+```
+
+Visit `http://localhost:5000` in the browser. Register a new user or log in with
+the credentials defined in the tests: `admin` / `admin` for administrator
+access.
+
+To populate the database with 10 sample users and assets run:
+
+```bash
+python sample_data.py
+```
+
+## Database Schema
+
+Two tables are used:
+
+- **User** – stores usernames, hashed passwords and roles (`admin` or
+  `regular`).
+- **Asset** – stores asset information such as name, type, serial number and
+  location. Each asset is linked to the user that created it.
+
+The tables include primary key fields (`id`) and a foreign key (`owner_id`)
+linking assets to users.
+
+## Programming Concepts
+
+- **Blueprints** modularise routes (`auth` for authentication and `asset` for
+  asset management).
+- **Flask-SQLAlchemy** provides an ORM layer – models are Python classes mapped
+  to tables. Queries use Python syntax rather than raw SQL.
+- **Flask-Login** handles session management so routes can require an
+  authenticated user.
+- **Templates** use Jinja2 syntax to render HTML dynamically, with control
+  structures like loops and conditionals.
+- **Validation** logic checks for empty fields and duplicate serial numbers,
+  showing messages when rules are broken.
+
+## Tests
+
+Run all tests with:
+
+```bash
+pytest
+```
+
+The tests create an isolated database, register users, log in and exercise CRUD
+operations to ensure the application behaves as expected.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,35 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+
+# Initialize extensions
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+login_manager.login_view = 'auth.login'
+
+
+def create_app(config=None):
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'dev'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+    login_manager.init_app(app)
+
+    # register blueprints
+    from .auth import auth_bp
+    from .assets import asset_bp
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(asset_bp)
+
+    return app
+
+
+def init_db(app):
+    """Create database tables."""
+    with app.app_context():
+        db.create_all()

--- a/app/assets.py
+++ b/app/assets.py
@@ -1,0 +1,63 @@
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_required, current_user
+from .models import Asset
+from . import db
+
+asset_bp = Blueprint('asset', __name__)
+
+@asset_bp.route('/')
+@login_required
+def list_assets():
+    assets = Asset.query.all()
+    return render_template('list_assets.html', assets=assets)
+
+@asset_bp.route('/asset/create', methods=['GET', 'POST'])
+@login_required
+def create_asset():
+    if request.method == 'POST':
+        if not current_user.is_authenticated:
+            return redirect(url_for('auth.login'))
+        name = request.form['name']
+        asset_type = request.form['asset_type']
+        serial_number = request.form['serial_number']
+        location = request.form['location']
+        if not all([name, asset_type, serial_number, location]):
+            flash('All fields required')
+            return redirect(url_for('asset.create_asset'))
+        if Asset.query.filter_by(serial_number=serial_number).first():
+            flash('Serial number must be unique')
+            return redirect(url_for('asset.create_asset'))
+        asset = Asset(name=name, asset_type=asset_type,
+                      serial_number=serial_number, location=location,
+                      owner_id=current_user.id)
+        db.session.add(asset)
+        db.session.commit()
+        flash('Asset created')
+        return redirect(url_for('asset.list_assets'))
+    return render_template('asset_form.html', action='Create')
+
+@asset_bp.route('/asset/<int:asset_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit_asset(asset_id):
+    asset = Asset.query.get_or_404(asset_id)
+    if request.method == 'POST':
+        asset.name = request.form['name']
+        asset.asset_type = request.form['asset_type']
+        asset.serial_number = request.form['serial_number']
+        asset.location = request.form['location']
+        db.session.commit()
+        flash('Asset updated')
+        return redirect(url_for('asset.list_assets'))
+    return render_template('asset_form.html', action='Edit', asset=asset)
+
+@asset_bp.route('/asset/<int:asset_id>/delete', methods=['POST'])
+@login_required
+def delete_asset(asset_id):
+    if current_user.role != 'admin':
+        flash('Only admin can delete assets')
+        return redirect(url_for('asset.list_assets'))
+    asset = Asset.query.get_or_404(asset_id)
+    db.session.delete(asset)
+    db.session.commit()
+    flash('Asset deleted')
+    return redirect(url_for('asset.list_assets'))

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,47 @@
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_user, logout_user, login_required
+from .models import User
+from . import db
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        role = request.form.get('role', 'regular')
+        if not username or not password:
+            flash('Username and password required')
+            return redirect(url_for('auth.register'))
+        if User.query.filter_by(username=username).first():
+            flash('Username already taken')
+            return redirect(url_for('auth.register'))
+        user = User(username=username, role=role)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registration successful')
+        return redirect(url_for('auth.login'))
+    return render_template('register.html')
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            flash('Logged in successfully')
+            return redirect(url_for('asset.list_assets'))
+        else:
+            flash('Invalid credentials')
+    return render_template('login.html')
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    flash('Logged out')
+    return redirect(url_for('auth.login'))

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,29 @@
+from . import db, login_manager
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(10), nullable=False)
+
+    assets = db.relationship('Asset', backref='owner', lazy=True)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+class Asset(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    asset_type = db.Column(db.String(50), nullable=False)
+    serial_number = db.Column(db.String(120), unique=True, nullable=False)
+    location = db.Column(db.String(120), nullable=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey('user.id'))

--- a/app/templates/asset_form.html
+++ b/app/templates/asset_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ action }} Asset</h2>
+<form method="post">
+  <label>Name<input type="text" name="name" value="{{ asset.name if asset else '' }}"></label>
+  <label>Type<input type="text" name="asset_type" value="{{ asset.asset_type if asset else '' }}"></label>
+  <label>Serial<input type="text" name="serial_number" value="{{ asset.serial_number if asset else '' }}"></label>
+  <label>Location<input type="text" name="location" value="{{ asset.location if asset else '' }}"></label>
+  <button type="submit">{{ action }}</button>
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Asset Manager</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css">
+<nav>
+  <a href="{{ url_for('asset.list_assets') }}">Assets</a>
+  {% if current_user.is_authenticated %}
+    <span>Logged in as {{ current_user.username }} ({{ current_user.role }})</span>
+    <a href="{{ url_for('auth.logout') }}">Logout</a>
+  {% else %}
+    <a href="{{ url_for('auth.login') }}">Login</a>
+  {% endif %}
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <ul class="messages">
+      {% for message in messages %}<li>{{ message }}</li>{% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>

--- a/app/templates/list_assets.html
+++ b/app/templates/list_assets.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Assets</h2>
+<a href="{{ url_for('asset.create_asset') }}">Add Asset</a>
+<table>
+<tr><th>Name</th><th>Type</th><th>Serial</th><th>Location</th><th>Owner</th><th>Actions</th></tr>
+{% for a in assets %}
+<tr>
+<td>{{ a.name }}</td><td>{{ a.asset_type }}</td><td>{{ a.serial_number }}</td><td>{{ a.location }}</td><td>{{ a.owner.username if a.owner else '' }}</td>
+<td>
+ <a href="{{ url_for('asset.edit_asset', asset_id=a.id) }}">Edit</a>
+ {% if current_user.role == 'admin' %}
+   <form method="post" action="{{ url_for('asset.delete_asset', asset_id=a.id) }}" style="display:inline" onsubmit="return confirm('Delete asset?');">
+     <button type="submit">Delete</button>
+   </form>
+ {% endif %}
+</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <label>Username<input type="text" name="username"></label>
+  <label>Password<input type="password" name="password"></label>
+  <button type="submit">Login</button>
+</form>
+<p>No account? <a href="{{ url_for('auth.register') }}">Register</a></p>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  <label>Username<input type="text" name="username"></label>
+  <label>Password<input type="password" name="password"></label>
+  <label>Role
+    <select name="role">
+      <option value="regular">Regular</option>
+      <option value="admin">Admin</option>
+    </select>
+  </label>
+  <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.0
+Flask-Login==0.6.3
+Flask-SQLAlchemy==3.1.1
+pytest==8.2.0

--- a/run.py
+++ b/run.py
@@ -1,0 +1,7 @@
+from app import create_app, init_db
+
+app = create_app()
+init_db(app)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/sample_data.py
+++ b/sample_data.py
@@ -1,0 +1,28 @@
+from app import create_app, db
+from app.models import User, Asset
+
+app = create_app()
+
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+    users = []
+    for i in range(10):
+        role = 'admin' if i == 0 else 'regular'
+        user = User(username=f'user{i}', role=role)
+        user.set_password('pass')
+        users.append(user)
+        db.session.add(user)
+    db.session.commit()
+
+    for i in range(10):
+        asset = Asset(
+            name=f'Asset{i}',
+            asset_type='Device',
+            serial_number=f'SN{i}',
+            location='Office',
+            owner_id=users[i % len(users)].id
+        )
+        db.session.add(asset)
+    db.session.commit()
+    print('Sample data inserted.')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,58 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import tempfile
+import pytest
+from app import create_app, db
+from app.models import User, Asset
+
+@pytest.fixture
+def client():
+    db_fd, db_path = tempfile.mkstemp()
+    app = create_app({'SQLALCHEMY_DATABASE_URI': 'sqlite:///' + db_path,
+                      'TESTING': True})
+    with app.test_client() as client:
+        with app.app_context():
+            db.create_all()
+            # create admin user
+            admin = User(username='admin', role='admin')
+            admin.set_password('admin')
+            db.session.add(admin)
+            db.session.commit()
+        yield client
+    os.close(db_fd)
+    os.unlink(db_path)
+
+
+def register(client, username, password, role='regular'):
+    return client.post('/register', data={'username': username, 'password': password, 'role': role}, follow_redirects=True)
+
+
+def login(client, username, password):
+    return client.post('/login', data={'username': username, 'password': password}, follow_redirects=True)
+
+
+def test_register_login(client):
+    rv = register(client, 'user1', 'pass')
+    assert b'Registration successful' in rv.data
+    rv = login(client, 'user1', 'pass')
+    assert b'Logged in successfully' in rv.data
+
+
+def test_asset_crud(client):
+    register(client, 'user1', 'pass')
+    login(client, 'user1', 'pass')
+    rv = client.post('/asset/create', data={'name': 'Laptop', 'asset_type': 'PC', 'serial_number': 'SN123', 'location': 'Office'}, follow_redirects=True)
+    assert b'Asset created' in rv.data
+    asset = Asset.query.first()
+    rv = client.post(f'/asset/{asset.id}/edit', data={'name': 'Laptop2', 'asset_type': 'PC', 'serial_number': 'SN123', 'location': 'Office'}, follow_redirects=True)
+    assert b'Asset updated' in rv.data
+
+    # regular user cannot delete
+    rv = client.post(f'/asset/{asset.id}/delete', follow_redirects=True)
+    assert b'Only admin can delete assets' in rv.data
+
+    # login as admin
+    login(client, 'admin', 'admin')
+    rv = client.post(f'/asset/{asset.id}/delete', follow_redirects=True)
+    assert b'Asset deleted' in rv.data


### PR DESCRIPTION
## Summary
- create Flask app with SQLAlchemy models and CRUD routes
- add templates and authentication
- populate sample data
- add tests verifying registration, login and role-based asset actions
- document agile workflow and usage in README

## Testing
- `pytest -q`
- `python sample_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6843988dc2dc832d8e481bbbd138f168